### PR TITLE
Feat: 기본 채팅 구현

### DIFF
--- a/src/main/java/com/ssginc/showpinglive/config/JwtSecurityConfig.java
+++ b/src/main/java/com/ssginc/showpinglive/config/JwtSecurityConfig.java
@@ -1,0 +1,20 @@
+package com.ssginc.showpinglive.config;
+
+import com.ssginc.showpinglive.jwt.JwtFilter;
+import com.ssginc.showpinglive.jwt.JwtUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.DefaultSecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@RequiredArgsConstructor
+public class JwtSecurityConfig extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
+    private final JwtUtil jwtUtil;
+
+    @Override
+    public void configure(HttpSecurity http) {
+        JwtFilter customFilter = new JwtFilter(jwtUtil);
+        http.addFilterBefore(customFilter, UsernamePasswordAuthenticationFilter.class);
+    }
+}

--- a/src/main/java/com/ssginc/showpinglive/config/JwtTokenProvider.java
+++ b/src/main/java/com/ssginc/showpinglive/config/JwtTokenProvider.java
@@ -1,0 +1,78 @@
+package com.ssginc.showpinglive.config;
+
+import com.ssginc.showpinglive.service.CustomUserDetailsService;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import java.util.Date;
+
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+
+    @Value("${jwt.access.expiration}")
+    private long validityInMilliseconds;
+
+    private final CustomUserDetailsService userDetailsService; // 사용자 정보를 가져오는 서비스
+
+    // JWT 토큰 생성
+    public String createToken(String username, String role) {
+        Claims claims = Jwts.claims().setSubject(username);
+        claims.put("role", role);
+
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + validityInMilliseconds);
+
+        System.out.println("======= validity: " + validity);
+        System.out.println("======== claims: " + claims);
+        System.out.println("======== role: " + role);
+        System.out.println("============ username: " + username);
+        System.out.println("============now: " + now);
+
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(validity)
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+    }
+
+    // JWT 토큰에서 인증 정보 추출
+    public Authentication getAuthentication(String token) {
+        UserDetails userDetails = userDetailsService.loadUserByUsername(getUsername(token));
+        return new UsernamePasswordAuthenticationToken(userDetails, "", userDetails.getAuthorities());
+    }
+
+    // JWT 토큰에서 사용자 이름 추출
+    public String getUsername(String token) {
+        return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody().getSubject();
+    }
+
+    // getUsername을 활용하여 별도의 메서드로 MemberId 추출 기능 제공
+    public String getMemberId(String token) {
+        return getUsername(token);
+    }
+
+
+    // JWT 토큰 유효성 검증
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/src/main/java/com/ssginc/showpinglive/config/WebSocketChatConfig.java
+++ b/src/main/java/com/ssginc/showpinglive/config/WebSocketChatConfig.java
@@ -1,0 +1,27 @@
+package com.ssginc.showpinglive.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketChatConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/sub"); // 구독 prefix
+        registry.setApplicationDestinationPrefixes("/pub"); // 발행 prefix
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws-stomp") // WebSocket 연결 Endpoint
+                .setAllowedOriginPatterns("*")
+                .withSockJS();
+        registry.addEndpoint("chat-websocket").withSockJS();
+        registry.addEndpoint("chatting-websocket").withSockJS();
+    }
+}

--- a/src/main/java/com/ssginc/showpinglive/config/WebSocketChatConfig.java
+++ b/src/main/java/com/ssginc/showpinglive/config/WebSocketChatConfig.java
@@ -1,14 +1,21 @@
 package com.ssginc.showpinglive.config;
 
+import com.ssginc.showpinglive.handler.WebSocketChatHandler;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
 @Configuration
 @EnableWebSocketMessageBroker
 public class WebSocketChatConfig implements WebSocketMessageBrokerConfigurer {
+    @Bean
+    public WebSocketChatHandler webSocketChatHandler() {
+        return new WebSocketChatHandler();
+    }
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
@@ -18,10 +25,8 @@ public class WebSocketChatConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/ws-stomp") // WebSocket 연결 Endpoint
+        registry.addEndpoint("/ws-stomp-chat") // WebSocket 연결 Endpoint
                 .setAllowedOriginPatterns("*")
                 .withSockJS();
-        registry.addEndpoint("chat-websocket").withSockJS();
-        registry.addEndpoint("chatting-websocket").withSockJS();
     }
 }

--- a/src/main/java/com/ssginc/showpinglive/config/WebSocketConfig.java
+++ b/src/main/java/com/ssginc/showpinglive/config/WebSocketConfig.java
@@ -1,5 +1,6 @@
 package com.ssginc.showpinglive.config;
 
+import com.ssginc.showpinglive.handler.WebSocketChatHandler;
 import com.ssginc.showpinglive.handler.WebSocketHandler;
 import org.kurento.client.KurentoClient;
 import org.springframework.context.annotation.Bean;
@@ -18,6 +19,9 @@ public class WebSocketConfig implements WebSocketConfigurer {
     }
 
     @Bean
+    public WebSocketChatHandler webSocketChatHandler() {return new WebSocketChatHandler();}
+
+    @Bean
     public KurentoClient kurentoClient() {
         return KurentoClient.create();
     }
@@ -32,5 +36,6 @@ public class WebSocketConfig implements WebSocketConfigurer {
     @Override
     public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
         registry.addHandler(webSocketHandler(), "/call");
+        registry.addHandler(webSocketChatHandler(), "/chat");
     }
 }

--- a/src/main/java/com/ssginc/showpinglive/controller/ChatController.java
+++ b/src/main/java/com/ssginc/showpinglive/controller/ChatController.java
@@ -3,6 +3,7 @@ package com.ssginc.showpinglive.controller;
 import com.ssginc.showpinglive.config.JwtTokenProvider;
 import com.ssginc.showpinglive.dto.object.ChatDto;
 import com.ssginc.showpinglive.entity.Member;
+import com.ssginc.showpinglive.jwt.JwtUtil;
 import com.ssginc.showpinglive.repository.MemberRepository;
 import com.ssginc.showpinglive.repository.StreamRepository;
 import com.ssginc.showpinglive.service.ChatService;
@@ -33,6 +34,7 @@ public class ChatController {
     private final MemberRepository memberRepository;
     private final StreamRepository streamRepository;
     private final JwtTokenProvider jwtTokenProvider;
+    private final JwtUtil jwtUtil;
 
     // 공통 메세지 저장 로직
     private ChatDto processAndSaveMessage(ChatDto chatDto) {
@@ -97,11 +99,17 @@ public class ChatController {
     @GetMapping("chatRoom")
     public String getChatRoom(HttpServletRequest request, Model model, @RequestParam Long chatRoomNo) {
         String memberId = null;
+        String memberRole = null;
+
         Cookie[] cookies = request.getCookies();
         if (cookies != null) {
             for (Cookie cookie : cookies) {
                 if ("accessToken".equals(cookie.getName())) {
+//                    memberId = jwtUtil.getUsernameFromToken(cookie.getValue());
                     memberId = jwtTokenProvider.getMemberId(cookie.getValue());
+//                    memberRole = jwtUtil.getRoleFromToken(cookie.getValue());
+                    System.out.println("[DEBUG] memberId: " + memberId);
+//                    System.out.println("[DEBUG] memberRole: " + memberRole);
                     break;
                 }
             }

--- a/src/main/java/com/ssginc/showpinglive/controller/ChatController.java
+++ b/src/main/java/com/ssginc/showpinglive/controller/ChatController.java
@@ -3,17 +3,14 @@ package com.ssginc.showpinglive.controller;
 import com.ssginc.showpinglive.dto.object.ChatDto;
 import com.ssginc.showpinglive.service.ChatService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.messaging.Message;
 import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
-import org.springframework.ui.Model;
+import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.Date;
 import java.util.List;
 
-@RestController
+@Controller
 @RequiredArgsConstructor
 @RequestMapping("chat") // REST API의 기본 경로 설정
 public class ChatController {
@@ -21,25 +18,32 @@ public class ChatController {
     private final SimpMessagingTemplate messagingTemplate; // WebSocket 메시지 전송
     private final ChatService chatService; // 채팅 서비스 로직
 
+    // 공통된 로직 추출
+    private ChatDto processAndSaveMessage(ChatDto chatDto) {
+        return chatService.saveChatMessage(
+                chatDto.getChatStreamNo(),
+                chatDto.getChatMemberNo(),
+                chatDto.getChatRoomNo(),
+                chatDto.getChatMessage(),
+                chatDto.getChatCreatedAt()
+        );
+    }
+
     // WebSocket 메시지 처리 (클라이언트에서 "/chat/message"로 메시지를 보낼 때 호출)
     @MessageMapping("/chat/message")
     public void sendMessage(ChatDto message) {
         try {
             // 채팅 메시지 저장 및 금칙어 필터링 처리
-            ChatDto savedMessage = chatService.saveChatMessage(
-                    message.getChatStreamNo(),
-                    message.getChatMemberNo(),
-                    message.getChatRoomNo(),
-                    message.getChatMessage()
-            );
+            ChatDto savedMessage = processAndSaveMessage(message);
 
             // WebSocket을 통해 클라이언트로 메시지 전송
             messagingTemplate.convertAndSend("/sub/chat/room/" + savedMessage.getChatRoomNo(), savedMessage);
 
         } catch (IllegalArgumentException e) {
             // 금칙어 포함 시 예외 처리 (필요 시 클라이언트로 알림)
-            messagingTemplate.convertAndSend("/sub/chat/room/" + message.getChatRoomNo(),
-                    "금칙어가 포함된 메시지는 전송할 수 없습니다.");
+            ChatDto errorResponse = new ChatDto();
+            errorResponse.setChatMessage("금칙어가 포함된 메시지는 전송할 수 없습니다.");
+            messagingTemplate.convertAndSend("/sub/chat/room/" + message.getChatRoomNo(), errorResponse);
         }
     }
 
@@ -48,18 +52,11 @@ public class ChatController {
     public ChatDto saveChat(@RequestBody ChatDto chatDto) {
         try {
             // 채팅 메시지 저장 및 반환
-            return chatService.saveChatMessage(
-                    chatDto.getChatStreamNo(),
-                    chatDto.getChatMemberNo(),
-                    chatDto.getChatRoomNo(),
-                    chatDto.getChatMessage()
-            );
+            return processAndSaveMessage(chatDto);
         } catch (IllegalArgumentException e) {
             throw new IllegalArgumentException("금칙어가 포함된 메시지는 저장할 수 없습니다.");
         }
     }
-
-
     /**
      * 특정 채팅방의 모든 메시지를 가져오는 REST API
      */
@@ -68,15 +65,15 @@ public class ChatController {
         return chatService.findMessagesByRoom(chatRoomNo);
     }
 
-    @GetMapping("/chatRoom")
-    public String getChatRoom(@RequestParam("chatRoomNo") Long chatRoomNo, Model model) {
-        // 클라이언트에서 전달받은 chatRoomNo를 모델에 추가
-        model.addAttribute("chatRoomNo", chatRoomNo);
-        return "chat/chatRoom"; // chatRoom.html 파일 반환
+//    @GetMapping("/chatRoom")
+//    public String getChatRoom(@RequestParam("chatRoomNo") Long chatRoomNo, Model model) {
+//        // 클라이언트에서 전달받은 chatRoomNo를 모델에 추가
+//        model.addAttribute("chatRoomNo", chatRoomNo);
+//        return "chat/chatRoom"; // chatRoom.html 파일 반환
+//    }
+
+    @GetMapping("chatRoom")
+    public String getChatRoom() {
+        return "chat/chatRoom";
     }
-
-    @GetMapping("chat")
-    public String chat() {return "chat/chat";}
-
-
 }

--- a/src/main/java/com/ssginc/showpinglive/controller/ChatController.java
+++ b/src/main/java/com/ssginc/showpinglive/controller/ChatController.java
@@ -1,13 +1,26 @@
 package com.ssginc.showpinglive.controller;
 
+import com.ssginc.showpinglive.config.JwtTokenProvider;
 import com.ssginc.showpinglive.dto.object.ChatDto;
+import com.ssginc.showpinglive.entity.Member;
+import com.ssginc.showpinglive.repository.MemberRepository;
+import com.ssginc.showpinglive.repository.StreamRepository;
 import com.ssginc.showpinglive.service.ChatService;
+import com.ssginc.showpinglive.service.CustomUserDetailsService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 
+import java.security.Principal;
 import java.util.List;
 
 @Controller
@@ -17,12 +30,14 @@ public class ChatController {
 
     private final SimpMessagingTemplate messagingTemplate; // WebSocket 메시지 전송
     private final ChatService chatService; // 채팅 서비스 로직
+    private final MemberRepository memberRepository;
+    private final StreamRepository streamRepository;
+    private final JwtTokenProvider jwtTokenProvider;
 
-    // 공통된 로직 추출
+    // 공통 메세지 저장 로직
     private ChatDto processAndSaveMessage(ChatDto chatDto) {
         return chatService.saveChatMessage(
-                chatDto.getChatStreamNo(),
-                chatDto.getChatMemberNo(),
+                chatDto.getChatMemberId(),
                 chatDto.getChatRoomNo(),
                 chatDto.getChatMessage(),
                 chatDto.getChatCreatedAt()
@@ -32,18 +47,24 @@ public class ChatController {
     // WebSocket 메시지 처리 (클라이언트에서 "/chat/message"로 메시지를 보낼 때 호출)
     @MessageMapping("/chat/message")
     public void sendMessage(ChatDto message) {
+        System.out.println("[DEBUG] Received message: " + message);
         try {
-            // 채팅 메시지 저장 및 금칙어 필터링 처리
             ChatDto savedMessage = processAndSaveMessage(message);
-
-            // WebSocket을 통해 클라이언트로 메시지 전송
-            messagingTemplate.convertAndSend("/sub/chat/room/" + savedMessage.getChatRoomNo(), savedMessage);
-
+            System.out.println("[DEBUG] Saved message: " + savedMessage);
+            if (savedMessage.getChatRoomNo() == null) {
+                System.err.println("[ERROR] savedMessage.getChatRoomNo() is null!");
+            }
+            String destination = "/sub/chat/room/" + savedMessage.getChatRoomNo();
+            messagingTemplate.convertAndSend(destination, savedMessage);
+            System.out.println("[DEBUG] Message sent to destination: " + destination);
         } catch (IllegalArgumentException e) {
-            // 금칙어 포함 시 예외 처리 (필요 시 클라이언트로 알림)
+            System.err.println("[ERROR] IllegalArgumentException in sendMessage: " + e.getMessage());
             ChatDto errorResponse = new ChatDto();
             errorResponse.setChatMessage("금칙어가 포함된 메시지는 전송할 수 없습니다.");
             messagingTemplate.convertAndSend("/sub/chat/room/" + message.getChatRoomNo(), errorResponse);
+        } catch (Exception e) {
+            System.err.println("[ERROR] Exception in sendMessage: " + e);
+            e.printStackTrace();
         }
     }
 
@@ -60,20 +81,115 @@ public class ChatController {
     /**
      * 특정 채팅방의 모든 메시지를 가져오는 REST API
      */
+    // 특정 채팅방의 모든 메시지 조회
     @GetMapping("/room/{chatRoomNo}")
     public List<ChatDto> getMessagesByRoom(@PathVariable Long chatRoomNo) {
         return chatService.findMessagesByRoom(chatRoomNo);
     }
 
-//    @GetMapping("/chatRoom")
-//    public String getChatRoom(@RequestParam("chatRoomNo") Long chatRoomNo, Model model) {
-//        // 클라이언트에서 전달받은 chatRoomNo를 모델에 추가
+//    @GetMapping("chatRoom")
+//    public String getChatRoom(Model model, @RequestParam Long chatRoomNo, Principal principal) {
 //        model.addAttribute("chatRoomNo", chatRoomNo);
-//        return "chat/chatRoom"; // chatRoom.html 파일 반환
+//        model.addAttribute("memberId", principal.getName());
+//        return "chat/chatRoom";
 //    }
 
     @GetMapping("chatRoom")
-    public String getChatRoom() {
+    public String getChatRoom(HttpServletRequest request, Model model, @RequestParam Long chatRoomNo) {
+        String memberId = null;
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if ("accessToken".equals(cookie.getName())) {
+                    memberId = jwtTokenProvider.getMemberId(cookie.getValue());
+                    break;
+                }
+            }
+        }
+        if (memberId == null) {
+            // 인증 정보가 없는 경우 로그인 페이지로 리다이렉트
+            return "redirect:/login";
+        }
+        model.addAttribute("chatRoomNo", chatRoomNo);
+        model.addAttribute("memberId", memberId);
         return "chat/chatRoom";
     }
+
+
+//    // 이후 수정
+//    @GetMapping("chatRoom")
+//    public String chatRoom(
+//            @RequestParam(required = false, defaultValue = "1") Long chatRoomNo,
+//            @RequestParam(required = false, defaultValue = "1") Long streamNo,
+//            Model model,
+//            @AuthenticationPrincipal User user
+//    ) {
+//
+////        // 인증 정보가 없으면 로그인 페이지로 리다이렉트
+////        if (user == null || "anonymousUser".equals(user.getUsername())) {
+////            return "redirect:/login";
+////        }
+//
+//        Member member = memberRepository.findByMemberId(user.getUsername())
+//                .orElseThrow(() -> new UsernameNotFoundException("해당 memberId의 멤버가 존재하지 않습니다."));
+//
+//        System.out.println("=======================================");
+//        System.out.println("userName: " + user.getUsername());
+//        System.out.println("streamNo: " + streamNo);
+//        System.out.println("=======================================");
+//
+//
+//
+//        // 2) Model에 담기
+//        model.addAttribute("chatRoomNo", chatRoomNo);
+//        model.addAttribute("streamNo", streamNo);
+//        model.addAttribute("memberNo", member.getMemberNo());
+//
+//        return "chat/chatRoom";  // chatRoom.html
+//    }
+
+    @PostMapping("/sendWithToken")
+    @ResponseBody
+    public ChatDto sendChatMessageWithToken(
+            @RequestBody ChatDto chatDto,
+            HttpServletRequest request) {
+
+        // 쿠키에서 accessToken 추출
+        String token = null;
+        if (request.getCookies() != null) {
+            for (Cookie cookie : request.getCookies()) {
+                if ("accessToken".equals(cookie.getName())) {
+                    token = cookie.getValue();
+                    break;
+                }
+            }
+        }
+        if (token == null) {
+            throw new RuntimeException("Access token not found in cookies");
+        }
+
+        // JWT 토큰에서 MemberId 추출
+        String memberId = jwtTokenProvider.getMemberId(token);
+
+        // JPQL을 사용하여 MemberRepository에서 로그인한 유저의 아이디로 Member 엔티티 조회
+        Member member = memberRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new UsernameNotFoundException("Member not found for memberId: " + memberId));
+
+        // 조회된 회원의 memberNo를 ChatDto에 설정 (JSON 형식으로 몽고디비에 전송)
+        chatDto.setChatMemberId(memberId);
+
+        // 채팅 메시지를 저장 및 후속 처리
+        ChatDto savedMessage = chatService.saveChatMessage(
+                member.getMemberId(),
+                chatDto.getChatRoomNo(),
+                chatDto.getChatMessage(),
+                chatDto.getChatCreatedAt()
+        );
+
+        // WebSocket을 통해 클라이언트에 메시지 전송
+        messagingTemplate.convertAndSend("/sub/chat/room/" + savedMessage.getChatRoomNo(), savedMessage);
+
+        return savedMessage;
+    }
+
 }

--- a/src/main/java/com/ssginc/showpinglive/controller/ChatController.java
+++ b/src/main/java/com/ssginc/showpinglive/controller/ChatController.java
@@ -1,0 +1,82 @@
+package com.ssginc.showpinglive.controller;
+
+import com.ssginc.showpinglive.dto.object.ChatDto;
+import com.ssginc.showpinglive.service.ChatService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Date;
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("chat") // REST API의 기본 경로 설정
+public class ChatController {
+
+    private final SimpMessagingTemplate messagingTemplate; // WebSocket 메시지 전송
+    private final ChatService chatService; // 채팅 서비스 로직
+
+    // WebSocket 메시지 처리 (클라이언트에서 "/chat/message"로 메시지를 보낼 때 호출)
+    @MessageMapping("/chat/message")
+    public void sendMessage(ChatDto message) {
+        try {
+            // 채팅 메시지 저장 및 금칙어 필터링 처리
+            ChatDto savedMessage = chatService.saveChatMessage(
+                    message.getChatStreamNo(),
+                    message.getChatMemberNo(),
+                    message.getChatRoomNo(),
+                    message.getChatMessage()
+            );
+
+            // WebSocket을 통해 클라이언트로 메시지 전송
+            messagingTemplate.convertAndSend("/sub/chat/room/" + savedMessage.getChatRoomNo(), savedMessage);
+
+        } catch (IllegalArgumentException e) {
+            // 금칙어 포함 시 예외 처리 (필요 시 클라이언트로 알림)
+            messagingTemplate.convertAndSend("/sub/chat/room/" + message.getChatRoomNo(),
+                    "금칙어가 포함된 메시지는 전송할 수 없습니다.");
+        }
+    }
+
+    // REST API를 통해 채팅 메시지 저장 (HTTP POST 요청 처리)
+    @PostMapping("/save")
+    public ChatDto saveChat(@RequestBody ChatDto chatDto) {
+        try {
+            // 채팅 메시지 저장 및 반환
+            return chatService.saveChatMessage(
+                    chatDto.getChatStreamNo(),
+                    chatDto.getChatMemberNo(),
+                    chatDto.getChatRoomNo(),
+                    chatDto.getChatMessage()
+            );
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("금칙어가 포함된 메시지는 저장할 수 없습니다.");
+        }
+    }
+
+
+    /**
+     * 특정 채팅방의 모든 메시지를 가져오는 REST API
+     */
+    @GetMapping("/room/{chatRoomNo}")
+    public List<ChatDto> getMessagesByRoom(@PathVariable Long chatRoomNo) {
+        return chatService.findMessagesByRoom(chatRoomNo);
+    }
+
+    @GetMapping("/chatRoom")
+    public String getChatRoom(@RequestParam("chatRoomNo") Long chatRoomNo, Model model) {
+        // 클라이언트에서 전달받은 chatRoomNo를 모델에 추가
+        model.addAttribute("chatRoomNo", chatRoomNo);
+        return "chat/chatRoom"; // chatRoom.html 파일 반환
+    }
+
+    @GetMapping("chat")
+    public String chat() {return "chat/chat";}
+
+
+}

--- a/src/main/java/com/ssginc/showpinglive/dto/object/ChatDto.java
+++ b/src/main/java/com/ssginc/showpinglive/dto/object/ChatDto.java
@@ -1,5 +1,7 @@
 package com.ssginc.showpinglive.dto.object;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -14,24 +16,22 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @Document(collection = "chat") // MongoDB Collection 이름
 public class ChatDto {
-    @Id
+    @JsonProperty("_id")
     private String id; // MongoDB의 _id 필드 (ObjectId를 String으로 매핑)
 
-    @Field("chat_no")
-    private Long chatNo; // chat_no 필드 (Int64)
+    @JsonProperty("chat_member_id")
+    private String chatMemberId;
 
-    @Field("chat_stream_no")
-    private Long chatStreamNo; // 스트림 번호 (Int64)
+    @JsonProperty("chat_room_no")
+    private Long chatRoomNo;
 
-    @Field("chat_member_no")
-    private Long chatMemberNo; // 회원 번호 (Int64)
+    @JsonProperty("chat_message")
+    private String chatMessage;
 
-    @Field("chat_room_no")
-    private Long chatRoomNo; // 채팅방 번호 (Int64)
-
-    @Field("chat_message")
-    private String chatMessage; // 메시지 내용
-
-    @Field("chat_created_at")
-    private LocalDateTime chatCreatedAt; // 생성 시간
+    @JsonProperty("chat_created_at")
+//    @JsonFormat(shape = JsonFormat.Shape.STRING,
+//            pattern = "yyyy. M. d. a h:mm:ss",
+//            locale = "ko",
+//            timezone = "Asia/Seoul")
+    private String chatCreatedAt; // 생성 시간
 }

--- a/src/main/java/com/ssginc/showpinglive/dto/object/ChatDto.java
+++ b/src/main/java/com/ssginc/showpinglive/dto/object/ChatDto.java
@@ -1,0 +1,37 @@
+package com.ssginc.showpinglive.dto.object;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Document(collection = "chat") // MongoDB Collection 이름
+public class ChatDto {
+    @Id
+    private String id; // MongoDB의 _id 필드 (ObjectId를 String으로 매핑)
+
+    @Field("chat_no")
+    private Long chatNo; // chat_no 필드 (Int64)
+
+    @Field("chat_stream_no")
+    private Long chatStreamNo; // 스트림 번호 (Int64)
+
+    @Field("chat_member_no")
+    private Long chatMemberNo; // 회원 번호 (Int64)
+
+    @Field("chat_room_no")
+    private Long chatRoomNo; // 채팅방 번호 (Int64)
+
+    @Field("chat_message")
+    private String chatMessage; // 메시지 내용
+
+    @Field("chat_created_at")
+    private LocalDateTime chatCreatedAt; // 생성 시간
+}

--- a/src/main/java/com/ssginc/showpinglive/dto/object/ForbiddenWord.java
+++ b/src/main/java/com/ssginc/showpinglive/dto/object/ForbiddenWord.java
@@ -1,0 +1,24 @@
+package com.ssginc.showpinglive.dto.object;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Document(collection = "forbiddenWord") // MongoDB Collection 이름
+public class ForbiddenWord {
+    @Id
+    private String id;        // MongoDB 자동 생성 ID
+
+    @Field("slang")
+    private String slang;      // 금칙어 단어
+
+    public CharSequence getWord() {
+        return slang;
+    }
+}

--- a/src/main/java/com/ssginc/showpinglive/handler/WebSocketChatHandler.java
+++ b/src/main/java/com/ssginc/showpinglive/handler/WebSocketChatHandler.java
@@ -1,36 +1,61 @@
 package com.ssginc.showpinglive.handler;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.socket.CloseStatus;
 import org.springframework.web.socket.TextMessage;
 import org.springframework.web.socket.WebSocketSession;
 import org.springframework.web.socket.handler.TextWebSocketHandler;
 
+import java.io.IOException;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class WebSocketChatHandler extends TextWebSocketHandler {
     private final ConcurrentHashMap<String, WebSocketSession> sessions = new ConcurrentHashMap<>();
+    private final Logger log = LoggerFactory.getLogger(WebSocketChatHandler.class);
+    private final Gson gson = new GsonBuilder().create();
 
     @Override
     public void afterConnectionEstablished(WebSocketSession session) throws Exception {
         sessions.put(session.getId(), session);
-        System.out.println("Chat WebSocket connected: " + session.getId());
+        log.info("채팅 연결됨: " + session.getId());
     }
 
     @Override
     public void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
-        String payload = message.getPayload();
-        System.out.println("Received chat message: " + payload);
 
-        // 메시지를 모든 연결된 클라이언트에게 브로드캐스트
+        // 클라이언트로부터 받은 메시지를 JSON 객체로 변환
+        JsonObject jsonMessage = gson.fromJson(message.getPayload(), JsonObject.class);
+        log.info("수신된 채팅 메시지: " + jsonMessage);
+
+        // 모든 연결된 클라이언트에게 메시지 브로드캐스트 (메시지는 JSON 문자열 그대로 전송)
         for (WebSocketSession client : sessions.values()) {
             if (client.isOpen()) {
-                client.sendMessage(new TextMessage(payload));
+                try {
+                    client.sendMessage(new TextMessage(jsonMessage.toString()));
+                } catch (IOException e) {
+                    log.error("메시지 전송 실패: " + e.getMessage());
+                }
             }
         }
     }
 
     @Override
-    public void afterConnectionClosed(WebSocketSession session, org.springframework.web.socket.CloseStatus status) throws Exception {
+    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) throws Exception {
         sessions.remove(session.getId());
-        System.out.println("Chat WebSocket disconnected: " + session.getId());
+        log.info("채팅 연결 종료됨: " + session.getId());
+    }
+
+    private void sendError(WebSocketSession session, String errorMsg) {
+        JsonObject response = new JsonObject();
+        response.addProperty("error", errorMsg);
+        try {
+            session.sendMessage(new TextMessage(response.toString()));
+        } catch (IOException e) {
+            log.error("에러 메시지 전송 실패: " + e.getMessage());
+        }
     }
 }

--- a/src/main/java/com/ssginc/showpinglive/handler/WebSocketChatHandler.java
+++ b/src/main/java/com/ssginc/showpinglive/handler/WebSocketChatHandler.java
@@ -1,0 +1,36 @@
+package com.ssginc.showpinglive.handler;
+
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+public class WebSocketChatHandler extends TextWebSocketHandler {
+    private final ConcurrentHashMap<String, WebSocketSession> sessions = new ConcurrentHashMap<>();
+
+    @Override
+    public void afterConnectionEstablished(WebSocketSession session) throws Exception {
+        sessions.put(session.getId(), session);
+        System.out.println("Chat WebSocket connected: " + session.getId());
+    }
+
+    @Override
+    public void handleTextMessage(WebSocketSession session, TextMessage message) throws Exception {
+        String payload = message.getPayload();
+        System.out.println("Received chat message: " + payload);
+
+        // 메시지를 모든 연결된 클라이언트에게 브로드캐스트
+        for (WebSocketSession client : sessions.values()) {
+            if (client.isOpen()) {
+                client.sendMessage(new TextMessage(payload));
+            }
+        }
+    }
+
+    @Override
+    public void afterConnectionClosed(WebSocketSession session, org.springframework.web.socket.CloseStatus status) throws Exception {
+        sessions.remove(session.getId());
+        System.out.println("Chat WebSocket disconnected: " + session.getId());
+    }
+}

--- a/src/main/java/com/ssginc/showpinglive/jwt/JwtFilter.java
+++ b/src/main/java/com/ssginc/showpinglive/jwt/JwtFilter.java
@@ -1,0 +1,71 @@
+package com.ssginc.showpinglive.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
+
+    private final JwtUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+
+        // 쿠키에서 JWT 토큰 추출
+        Optional<String> tokenOptional = Arrays.stream(Optional.ofNullable(request.getCookies()).orElse(new Cookie[0]))
+                .filter(cookie -> "accessToken".equals(cookie.getName()))
+                .map(Cookie::getValue)
+                .findFirst();
+
+        if (tokenOptional.isPresent()) {
+            String token = tokenOptional.get();
+            System.out.println(">>>>>>>>>>>>> Extracted accessToken: " + token);
+
+            if (jwtUtil.validateToken(token)) {
+                String username = jwtUtil.getUsernameFromToken(token);
+                String role = jwtUtil.getRoleFromToken(token);
+                System.out.println("==================>>> " + username + " ********** " + role);
+                System.out.println("+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++");
+
+
+                // ✅ Spring Security 권한 형식으로 변환
+                List<SimpleGrantedAuthority> authorities = Collections.singletonList(new SimpleGrantedAuthority(role));
+
+                UserDetails userDetails = User.withUsername(username)
+                        .password("") // ✅ 더미 값 사용 (보안 강화)
+                        .authorities(authorities) // ✅ 권한 설정 변경
+                        .build();
+
+                System.out.println("=======================>>>> getUsername >> " + userDetails.getUsername() + "=====================");
+
+
+                UsernamePasswordAuthenticationToken authToken =
+                        new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                SecurityContextHolder.getContext().setAuthentication(authToken);
+            }
+        }
+
+
+
+        chain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/ssginc/showpinglive/jwt/JwtUtil.java
+++ b/src/main/java/com/ssginc/showpinglive/jwt/JwtUtil.java
@@ -1,0 +1,115 @@
+package com.ssginc.showpinglive.jwt;
+
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.util.Date;
+import java.util.Map;
+
+@Component
+public class JwtUtil {
+
+    private final Key key;
+    private final long accessTokenExpiration;
+    private final long refreshTokenExpiration;
+
+    public JwtUtil(@Value("${jwt.secret}") String secret,
+                   @Value("${jwt.access.expiration}") long accessTokenExpiration,
+                   @Value("${jwt.refresh.expiration}") long refreshTokenExpiration) {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes());
+        this.accessTokenExpiration = accessTokenExpiration;
+        this.refreshTokenExpiration = refreshTokenExpiration;
+    }
+
+//    // **JWT 생성 (Role 포함)**
+//    public String generateToken(String memberId, String role) {
+//        return Jwts.builder()
+//                .setSubject(memberId)
+//                .addClaims(Map.of("role",role))
+//                .setExpiration(new Date(System.currentTimeMillis() + expiration))
+//                .signWith(key, SignatureAlgorithm.HS256)
+//                .compact();
+//    }
+
+    // Access Token 생성 (30분 만료)
+    public String generateAccessToken(String memberId, String role) {
+
+        System.out.println("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@");
+        System.out.println("generateAccessToken 실행됨");
+        System.out.println("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@");
+        return Jwts.builder()
+                .setSubject(memberId) // 사용자 ID 저장
+                .claim("role", role)  // 권한(role) 추가
+                .setIssuedAt(new Date()) // 토큰 발행 시간
+                .setExpiration(new Date(System.currentTimeMillis() + accessTokenExpiration)) // Access Token 만료 시간 설정
+                .signWith(key, SignatureAlgorithm.HS256) // 서명
+                .compact();
+
+    }
+
+    // ✅ Refresh Token 생성 (7일 만료)
+    public String generateRefreshToken(String memberId) {
+
+        System.out.println("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@");
+        System.out.println("generateRefreshToken 실행됨");
+        System.out.println("@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@");
+        return Jwts.builder()
+                .setSubject(memberId)
+                .setIssuedAt(new Date())
+                .setExpiration(new Date(System.currentTimeMillis() + refreshTokenExpiration)) // Refresh Token 만료 시간
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    // **JWT에서 사용자 ID 추출
+    public String getUsernameFromToken(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+    }
+
+    // JWT에서 권한 추출
+    public String getRoleFromToken(String token) {
+        String role = (String) Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .get("role");
+        return role;
+    }
+
+    // JWT 유효성 검증
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    // JWT 만료 여부 확인
+    public boolean idTokenExpired(String token) {
+        try {
+            Date expiration = Jwts.parserBuilder()
+                    .setSigningKey(key)
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody()
+                    .getExpiration();
+            return expiration.before(new Date());
+        } catch (ExpiredJwtException e) {
+            return true; // 이미 만료됨
+        }
+    }
+}

--- a/src/main/java/com/ssginc/showpinglive/repository/ChatRepository.java
+++ b/src/main/java/com/ssginc/showpinglive/repository/ChatRepository.java
@@ -1,0 +1,14 @@
+package com.ssginc.showpinglive.repository;
+
+import com.ssginc.showpinglive.dto.object.ChatDto;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ChatRepository extends MongoRepository<ChatDto, String> {
+
+    List<ChatDto> findByChatRoomNo(Long chatRoomNo);
+
+}

--- a/src/main/java/com/ssginc/showpinglive/repository/ChatRoomRepository.java
+++ b/src/main/java/com/ssginc/showpinglive/repository/ChatRoomRepository.java
@@ -1,0 +1,9 @@
+package com.ssginc.showpinglive.repository;
+
+import com.ssginc.showpinglive.entity.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+}

--- a/src/main/java/com/ssginc/showpinglive/repository/ForbiddenWordRepository.java
+++ b/src/main/java/com/ssginc/showpinglive/repository/ForbiddenWordRepository.java
@@ -1,0 +1,11 @@
+package com.ssginc.showpinglive.repository;
+
+import com.ssginc.showpinglive.dto.object.ForbiddenWord;
+import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ForbiddenWordRepository extends MongoRepository<ForbiddenWord, String> {
+    // 금칙어 검색을 위한 메서드 예시
+    boolean existsBySlang(String slang);
+}

--- a/src/main/java/com/ssginc/showpinglive/service/ChatService.java
+++ b/src/main/java/com/ssginc/showpinglive/service/ChatService.java
@@ -1,0 +1,51 @@
+package com.ssginc.showpinglive.service;
+
+import com.ssginc.showpinglive.dto.object.ChatDto;
+import com.ssginc.showpinglive.dto.object.ForbiddenWord;
+import com.ssginc.showpinglive.repository.ChatRepository;
+import com.ssginc.showpinglive.repository.ForbiddenWordRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ChatService {
+
+    private final ChatRepository chatRepository; // 변수명 통일 (chatMessageRepository -> chatRepository)
+    private final ForbiddenWordRepository forbiddenWordRepository;
+
+    public ChatDto saveChatMessage(Long chatStreamNo, Long chatMemberNo, Long chatRoomNo, String chatMessage) {
+        // 1. 금칙어 필터링 로직
+        if (isForbiddenWordIncluded(chatMessage)) {
+            throw new IllegalArgumentException("금칙어가 포함된 메시지는 전송할 수 없습니다.");
+        }
+
+        // 2. 채팅 메시지 저장
+        ChatDto message = new ChatDto();
+        message.setChatStreamNo(chatStreamNo);
+        message.setChatMemberNo(chatMemberNo);
+        message.setChatRoomNo(chatRoomNo);
+        message.setChatMessage(chatMessage);
+        message.setChatCreatedAt(LocalDateTime.now());
+
+        return chatRepository.save(message); // MongoDB에 저장
+    }
+
+    // 금칙어 필터링 로직을 별도 메서드로 분리
+    private boolean isForbiddenWordIncluded(String message) {
+        List<ForbiddenWord> forbiddenWords = forbiddenWordRepository.findAll();
+        for (ForbiddenWord slang : forbiddenWords) {
+            if (message.contains(slang.getWord())) {
+                return true; // 금칙어가 포함된 경우
+            }
+        }
+        return false; // 금칙어가 없는 경우
+    }
+
+    public List<ChatDto> findMessagesByRoom(Long chatRoomNo) {
+        return chatRepository.findByChatRoomNo(chatRoomNo);
+    }
+}

--- a/src/main/java/com/ssginc/showpinglive/service/ChatService.java
+++ b/src/main/java/com/ssginc/showpinglive/service/ChatService.java
@@ -14,10 +14,10 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ChatService {
 
-    private final ChatRepository chatRepository; // 변수명 통일 (chatMessageRepository -> chatRepository)
+    private final ChatRepository chatRepository;
     private final ForbiddenWordRepository forbiddenWordRepository;
 
-    public ChatDto saveChatMessage(Long chatStreamNo, Long chatMemberNo, Long chatRoomNo, String chatMessage) {
+    public ChatDto saveChatMessage(Long chatStreamNo, Long chatMemberNo, Long chatRoomNo, String chatMessage, LocalDateTime chatCreatedAt) {
         // 1. 금칙어 필터링 로직
         if (isForbiddenWordIncluded(chatMessage)) {
             throw new IllegalArgumentException("금칙어가 포함된 메시지는 전송할 수 없습니다.");

--- a/src/main/java/com/ssginc/showpinglive/service/CustomUserDetailsService.java
+++ b/src/main/java/com/ssginc/showpinglive/service/CustomUserDetailsService.java
@@ -1,0 +1,45 @@
+package com.ssginc.showpinglive.service;
+
+import com.ssginc.showpinglive.entity.Member;
+import com.ssginc.showpinglive.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        // 데이터베이스에서 사용자 정보 조회
+        Member member = memberRepository.findByMemberId(username)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + username));
+
+        // Spring Security의 User 객체로 변환
+        return User.builder()
+                .username(member.getMemberId())
+                .password(member.getMemberPassword()) // 비밀번호는 암호화된 상태여야 함 (BCrypt 등)
+                .roles(member.getMemberRole().name()) // ROLE_USER, ROLE_ADMIN 등
+                .build();
+    }
+
+    public Long getMemberNo(){
+// SecurityContextHolder에서 현재    인증된 사용자의 username(=memberId) 가져오기
+        String memberId = SecurityContextHolder.getContext().getAuthentication().getName();
+        // memberId를 통해 DB에서 Member 엔티티 조회
+        System.out.println("<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<");
+        System.out.println("memberId" + memberId);
+        System.out.println("<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<");
+        Member member = memberRepository.findByMemberId(memberId)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + memberId));
+
+        return member.getMemberNo();
+    }
+}

--- a/src/main/java/com/ssginc/showpinglive/service/KafkaConsumerService.java
+++ b/src/main/java/com/ssginc/showpinglive/service/KafkaConsumerService.java
@@ -1,0 +1,50 @@
+package com.ssginc.showpinglive.service;
+
+import com.ssginc.showpinglive.dto.object.ChatDto;
+import com.ssginc.showpinglive.repository.ChatRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class KafkaConsumerService {
+
+    private final ChatRepository chatRepository;
+    private final SimpMessagingTemplate messagingTemplate; // WebSocket 메시지 전송용
+
+    private long kafka_time = 0;
+    private long kafka_count = 0;
+
+    /**
+     * Kafka에서 ChatDto 메시지를 소비하고 처리
+     * @param chatDto Kafka에서 수신한 채팅 메시지 객체
+     */
+    @KafkaListener(topics = "chat-messages", groupId = "chat-consumer-group")
+    public void consumeMessage(ChatDto chatDto) {
+        long startTime = System.currentTimeMillis();
+        kafka_count++;
+
+        System.out.println("Received chat message: " + chatDto);
+
+
+        try {
+            // 특정 채팅방(/sub/chat/room/{chatRoomNo})으로 메시지를 실시간 전송
+            messagingTemplate.convertAndSend("/sub/chat/room/" + chatDto.getChatRoomNo(), chatDto);
+            chatRepository.save(chatDto);
+            System.out.println(kafka_count + "받은 chat 몽고디비에 저장됨.");
+
+            long endTime = System.currentTimeMillis();
+            System.out.println(">>>>>>> 메세지 처리시간 : " + (endTime - startTime) + "ms");
+            kafka_time = endTime - startTime;
+
+            System.out.println(kafka_count + ">> kafka_time ==========> " + kafka_time);
+            System.out.println("Chat saved to MongoDB " + chatDto.getChatMessage());
+        } catch (Exception e) {
+            System.err.println("Error processing Kafka message: " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+
+}

--- a/src/main/java/com/ssginc/showpinglive/service/KafkaProducerService.java
+++ b/src/main/java/com/ssginc/showpinglive/service/KafkaProducerService.java
@@ -1,4 +1,5 @@
 package com.ssginc.showpinglive.service;
+
 import com.ssginc.showpinglive.dto.object.ChatDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -9,8 +10,16 @@ import org.springframework.stereotype.Service;
 public class KafkaProducerService {
 
     private final KafkaTemplate<String, ChatDto> kafkaTemplate;
-
-    public void send(String topic, ChatDto message) {
-        kafkaTemplate.send(topic, message);
+    private static final String TOPIC = "chat-messages"; // Kafka 토픽 이름
+    /**
+     * ChatDto 메시지를 Kafka로 전송
+     * @param chatDto 전송할 채팅 메시지 객체
+     */
+    public void sendMessage(ChatDto chatDto) {
+        try {
+            kafkaTemplate.send(TOPIC, chatDto); // Kafka로 메시지 전송
+        } catch (Exception e) {
+            System.err.println("Error sending message to Kafka: " + e.getMessage());
+        }
     }
 }

--- a/src/main/java/com/ssginc/showpinglive/service/KafkaProducerService.java
+++ b/src/main/java/com/ssginc/showpinglive/service/KafkaProducerService.java
@@ -1,0 +1,16 @@
+package com.ssginc.showpinglive.service;
+import com.ssginc.showpinglive.dto.object.ChatDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class KafkaProducerService {
+
+    private final KafkaTemplate<String, ChatDto> kafkaTemplate;
+
+    public void send(String topic, ChatDto message) {
+        kafkaTemplate.send(topic, message);
+    }
+}

--- a/src/main/resources/static/css/chat/chat.css
+++ b/src/main/resources/static/css/chat/chat.css
@@ -1,0 +1,77 @@
+/* 전체 크기 설정 */
+.chat-container {
+    width: 300px;
+    height: 480px;
+    border: 1px solid #ddd;
+    border-radius: 5px;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+}
+
+/* 공지 스타일 */
+#announcement {
+    background-color: #ffe6e6;
+    color: #d9534f;
+    font-weight: bold;
+    text-align: center;
+    padding: 10px;
+    margin: 0; /* 여백 제거 */
+}
+
+/* 채팅 메시지 영역 */
+.chat-messages {
+    flex-grow: 1; /* 메시지 영역이 남은 공간을 차지 */
+    overflow-y: auto;
+    padding: 10px;
+    /*background-color: #f9f9f9;*/
+}
+
+/* 최신 채팅으로 이동 버튼 */
+.scroll-button {
+    position: absolute;
+    bottom: 60px; /* 입력창 바로 위에 위치 */
+    left: 50%;
+    transform: translateX(-50%);
+    background-color: #E5E2E2;
+    color: white;
+    border-radius: 5px;
+    padding: 5px 10px;
+    border: none;
+    cursor: pointer;
+}
+
+.scroll-button:hover {
+    background-color: #ec971f;
+}
+
+/* 입력창 스타일 */
+.input-container {
+    position: absolute; /* 항상 하단에 고정 */
+    bottom: 0; /* 부모 요소의 하단에 붙임 */
+    left: 0;
+    width: 100%;
+    display: flex;
+    background-color: #F4F4F4;
+}
+
+#message-input {
+    flex-grow: 1; /* 입력창이 가로로 확장 */
+    padding: 10px;
+    border: none; /* 테두리 제거 */
+    border-radius: 0 0 0 5px; /* 아래 왼쪽 모서리 둥글게 */
+    outline: none; /* 포커스 시 테두리 제거 */
+}
+
+#send-button {
+    padding: 10px;
+    background-color: #ccc; /* 회색으로 변경 */
+    color: white;
+    border: none; /* 테두리 제거 */
+    border-radius: 0 0 5px 0; /* 아래 오른쪽 모서리 둥글게 */
+    cursor: pointer;
+}
+
+#send-button:hover {
+    background-color: #bbb; /* hover 상태에서 더 어두운 회색 */
+}

--- a/src/main/resources/static/css/chat/chat.css
+++ b/src/main/resources/static/css/chat/chat.css
@@ -89,18 +89,18 @@
 
 /* 채팅 메시지 래퍼 */
 .chat-wrapper {
-    flex: 1;               /* 위/아래로 늘어나도록 설정 */
-    overflow-y: auto;      /* 스크롤 가능 */
-    padding-bottom: 70px;  /* input-container가 겹치지 않도록 하단 여백 */
+    flex: 1; /* 위/아래로 늘어나도록 설정 */
+    overflow-y: auto; /* 스크롤 가능 */
+    padding-bottom: 70px; /* input-container가 겹치지 않도록 하단 여백 */
 }
 
 /* 입력 영역: 항상 하단 중앙 고정 */
 .input-container {
-    position: absolute;    /* 부모 .chat-container 기준 */
-    bottom: 0;             /* 하단에 붙임 */
-    left: 50%;             /* 수평 중앙 */
+    position: absolute; /* 부모 .chat-container 기준 */
+    bottom: 0; /* 하단에 붙임 */
+    left: 50%; /* 수평 중앙 */
     transform: translateX(-50%); /* 수평 중앙 정렬 보정 */
-    width: 100%;            /* 예시, 필요에 따라 조정 */
+    width: 100%; /* 예시, 필요에 따라 조정 */
     display: flex;
     background-color: #fff;
     /*padding: 10px;*/
@@ -124,3 +124,91 @@
 /*    color: #fff;*/
 /*    cursor: pointer;*/
 /*}*/
+
+
+.report-modal {
+    display: none; /* 초기에는 숨김 */
+    width: 320px;
+    margin: 50px auto; /* 화면 중앙 정렬 */
+    background-color: #ffffff;
+    border-radius: 10px;
+    padding: 20px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 9999; /* 채팅창 위에 표시 */
+}
+
+/* 모달 배경(반투명) */
+.modal-overlay {
+    display: none; /* 초기에는 숨김 */
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.4);
+    z-index: 9998;
+}
+
+.report-modal h2 {
+    margin-top: 0;
+    margin-bottom: 10px;
+    font-size: 18px;
+    text-align: center;
+}
+
+.description {
+    font-size: 14px;
+    margin-bottom: 20px;
+}
+
+.radio-group {
+    margin-bottom: 20px;
+}
+
+.radio-label {
+    display: block;
+    margin-bottom: 10px;
+    font-size: 14px;
+    cursor: pointer;
+}
+
+.radio-label input[type="radio"] {
+    margin-right: 8px;
+}
+
+.report-content {
+    margin-bottom: 20px;
+    padding: 10px;
+    background-color: #f9f9f9;
+    border-radius: 6px;
+    font-size: 14px;
+}
+
+.button-group {
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+}
+
+#cancelBtn,
+#submitBtn {
+    padding: 8px 16px;
+    font-size: 14px;
+    cursor: pointer;
+    border: none;
+    border-radius: 4px;
+}
+
+#cancelBtn {
+    background-color: #ccc;
+    color: #333;
+}
+
+#submitBtn {
+    background-color: #f05d5e;
+    color: #fff;
+}

--- a/src/main/resources/static/css/chat/chat.css
+++ b/src/main/resources/static/css/chat/chat.css
@@ -1,77 +1,126 @@
-/* 전체 크기 설정 */
+/* Chat Room Container */
 .chat-container {
+    position: relative;
+    width: 100%;
     width: 300px;
     height: 480px;
     border: 1px solid #ddd;
     border-radius: 5px;
     overflow: hidden;
+    font-family: Arial, sans-serif;
     display: flex;
     flex-direction: column;
 }
 
-/* 공지 스타일 */
-#announcement {
+/* Announcement Section */
+.announcement {
     background-color: #ffe6e6;
-    color: #d9534f;
+    color: #ff6666;
     font-weight: bold;
-    text-align: center;
     padding: 10px;
-    margin: 0; /* 여백 제거 */
+    text-align: center;
+    font-size: 14px;
+    border-bottom: 1px solid #ddd;
 }
 
-/* 채팅 메시지 영역 */
+/* Chat Messages Section */
 .chat-messages {
-    flex-grow: 1; /* 메시지 영역이 남은 공간을 차지 */
+    flex-grow: 1;
     overflow-y: auto;
     padding: 10px;
     /*background-color: #f9f9f9;*/
+    margin-bottom: 10px;
+    font-size: 14px;
 }
 
-/* 최신 채팅으로 이동 버튼 */
+.chat-message .message {
+    color: #555; /* 메시지 텍스트 색상 */
+}
+
+.chat-message .username {
+    font-weight: bold;
+    margin-right: 5px;
+}
+
+.chat-message.admin .username {
+    color: #ff6666; /* 관리자 메시지 색상 */
+}
+
+.chat-message.user .username {
+    color: #333; /* 일반 사용자 메시지 색상 */
+}
+
+/* Scroll to Latest Button */
 .scroll-button {
-    position: absolute;
-    bottom: 60px; /* 입력창 바로 위에 위치 */
-    left: 50%;
-    transform: translateX(-50%);
-    background-color: #E5E2E2;
+    position: sticky;
+    bottom: 10px;
+    margin-top: 10px;
+    background-color: #007bff;
     color: white;
-    border-radius: 5px;
-    padding: 5px 10px;
     border: none;
+    border-radius: 3px;
+    padding: 5px 10px;
     cursor: pointer;
+    display: none;
+    /* 기본적으로 숨김 */
 }
 
-.scroll-button:hover {
-    background-color: #ec971f;
-}
-
-/* 입력창 스타일 */
+/* Input Section */
 .input-container {
-    position: absolute; /* 항상 하단에 고정 */
-    bottom: 0; /* 부모 요소의 하단에 붙임 */
-    left: 0;
-    width: 100%;
     display: flex;
-    background-color: #F4F4F4;
+    border-top: #f9f9f9;
+    padding: 10px;
 }
 
-#message-input {
-    flex-grow: 1; /* 입력창이 가로로 확장 */
-    padding: 10px;
-    border: none; /* 테두리 제거 */
-    border-radius: 0 0 0 5px; /* 아래 왼쪽 모서리 둥글게 */
-    outline: none; /* 포커스 시 테두리 제거 */
+.input-container input {
+    flex-grow: 1;
+    border: 1px solid #ddd;
+    border-radius: 3px;
+    padding: 5px;
 }
 
-#send-button {
-    padding: 10px;
-    background-color: #ccc; /* 회색으로 변경 */
+.input-container button {
+    background-color: #007bff;
     color: white;
-    border: none; /* 테두리 제거 */
-    border-radius: 0 0 5px 0; /* 아래 오른쪽 모서리 둥글게 */
-    cursor: pointer;
+    border: none;
+    border-radius: 3px;
+    padding: 5px 10px;
 }
 
-#send-button:hover {
-    background-color: #bbb; /* hover 상태에서 더 어두운 회색 */
+/* 채팅 메시지 래퍼 */
+.chat-wrapper {
+    flex: 1;               /* 위/아래로 늘어나도록 설정 */
+    overflow-y: auto;      /* 스크롤 가능 */
+    padding-bottom: 70px;  /* input-container가 겹치지 않도록 하단 여백 */
 }
+
+/* 입력 영역: 항상 하단 중앙 고정 */
+.input-container {
+    position: absolute;    /* 부모 .chat-container 기준 */
+    bottom: 0;             /* 하단에 붙임 */
+    left: 50%;             /* 수평 중앙 */
+    transform: translateX(-50%); /* 수평 중앙 정렬 보정 */
+    width: 100%;            /* 예시, 필요에 따라 조정 */
+    display: flex;
+    background-color: #fff;
+    /*padding: 10px;*/
+    /*box-shadow: 0 -1px 5px rgba(0,0,0,0.1);*/
+}
+
+/*!* 메시지 입력 필드와 전송 버튼 *!*/
+/*#message-input {*/
+/*    flex: 1;*/
+/*    padding: 5px;*/
+/*    border: 1px solid #ccc;*/
+/*    !*border-radius: 3px;*!*/
+/*}*/
+
+/*#send-button {*/
+/*    margin-left: 10px;*/
+/*    padding: 5px 10px;*/
+/*    border: none;*/
+/*    border-radius: 3px;*/
+/*    background-color: #007bff;*/
+/*    color: #fff;*/
+/*    cursor: pointer;*/
+/*}*/

--- a/src/main/resources/static/css/chat/chat.css
+++ b/src/main/resources/static/css/chat/chat.css
@@ -1,7 +1,6 @@
 /* Chat Room Container */
 .chat-container {
     position: relative;
-    width: 100%;
     width: 300px;
     height: 480px;
     border: 1px solid #ddd;
@@ -26,11 +25,13 @@
 /* Chat Messages Section */
 .chat-messages {
     flex-grow: 1;
+    /*height: calc(100% - 140px); !* 전체 높이에서 입력 영역(예: 50px)과 공지 영역(예: 50px) 등을 뺀 높이 *!*/
     overflow-y: auto;
     padding: 10px;
     /*background-color: #f9f9f9;*/
     margin-bottom: 10px;
     font-size: 14px;
+    padding-bottom: 40px;
 }
 
 .chat-message .message {
@@ -50,19 +51,21 @@
     color: #333; /* 일반 사용자 메시지 색상 */
 }
 
-/* Scroll to Latest Button */
+/* 최신 채팅으로 이동 버튼 */
 .scroll-button {
-    position: sticky;
-    bottom: 10px;
-    margin-top: 10px;
-    background-color: #007bff;
-    color: white;
-    border: none;
-    border-radius: 3px;
+    position: absolute;
+    bottom: 55px; /* 입력 영역 높이(예: 50px) 위에 약간의 여유 (10px) */
+    left: 50%;
+    transform: translateX(-50%);
     padding: 5px 10px;
+    font-size: 12px;
+    background-color: #333;
+    color: #fff;
+    border: none;
+    border-radius: 4px;
     cursor: pointer;
-    display: none;
-    /* 기본적으로 숨김 */
+    z-index: 10;
+    /* display는 JavaScript에서 제어 */
 }
 
 /* Input Section */
@@ -89,9 +92,12 @@
 
 /* 채팅 메시지 래퍼 */
 .chat-wrapper {
+    position: relative;
+    height: 440px;
     flex: 1; /* 위/아래로 늘어나도록 설정 */
     overflow-y: auto; /* 스크롤 가능 */
     padding-bottom: 70px; /* input-container가 겹치지 않도록 하단 여백 */
+    border: 1px solid #ddd; /* (선택) 영역 구분을 위한 스타일 */
 }
 
 /* 입력 영역: 항상 하단 중앙 고정 */
@@ -211,4 +217,9 @@
 #submitBtn {
     background-color: #f05d5e;
     color: #fff;
+}
+
+.user-name {
+    font-weight: bold;
+    cursor: pointer;
 }

--- a/src/main/resources/static/js/chat/chatRoom.js
+++ b/src/main/resources/static/js/chat/chatRoom.js
@@ -1,0 +1,193 @@
+let stompClient = null;
+let reconnectTimeout = 5000;
+
+window.onload = function() {
+
+    // 쿠키에서 accessToken 추출
+    const accessToken = getCookieValue("accessToken");
+    console.log("AccessToken:", accessToken);
+
+// JWT 페이로드 디코딩
+    const payload = parseJwt(accessToken);
+    console.log("JWT Payload:", payload);
+
+// 만약 JWT 페이로드에 memberId나 sub 필드가 있다면:
+    const extractedMemberId = payload ? payload.sub || payload.memberId : null;
+    console.log("추출된 MemberId:", extractedMemberId);
+
+    console.log("chatRoomNo =", chatRoomNo); // Thymeleaf 치환 결과 확인
+    console.log("memberId =", memberId);
+
+    const chat = document.getElementById('chat-container');
+    document.getElementById('send-button').addEventListener('click', sendChatMessage);
+    connectToChatRoom();  // STOMP 연결 초기화
+};
+
+function connectToChatRoom() {
+    const socket = new SockJS('/ws-stomp-chat');
+    stompClient = Stomp.over(socket);
+
+    stompClient.connect({}, onConnected, onError);
+}
+
+// 연결 성공 콜백
+function onConnected(frame) {
+    console.log('Connected to WebSocket:', frame);
+
+    // 채팅방 구독
+    stompClient.subscribe(`/sub/chat/room/${chatRoomNo}`, function (message) {
+        console.log("Received message from subscription:", message);
+        try {
+            const parsedMessage = JSON.parse(message.body);
+            console.log("Parsed message:", parsedMessage);
+            addMessageToChat(parsedMessage);
+        } catch (e) {
+            console.error("Error parsing message:", e);
+        }
+    });
+}
+
+// 연결 에러 콜백
+function onError(error) {
+    console.error('STOMP error:', error);
+
+    // 일정 시간 후 재연결 시도
+    setTimeout(function() {
+        console.log('Attempting to reconnect...');
+        connectToChatRoom();
+    }, reconnectTimeout);
+}
+
+function createChatRoom() {
+    const chatContainer = document.getElementById('chat-container');
+    const scrollToLatestButton = document.getElementById('scroll-to-latest');
+
+    chatContainer.addEventListener('scroll', function () {
+        if (chatContainer.scrollTop + chatContainer.clientHeight < chatContainer.scrollHeight) {
+            scrollToLatestButton.style.display = 'block';
+        } else {
+            scrollToLatestButton.style.display = 'none';
+        }
+    });
+
+    scrollToLatestButton.addEventListener('click', function () {
+        chatContainer.scrollTop = chatContainer.scrollHeight;
+        scrollToLatestButton.style.display = 'none';
+    });
+
+
+}
+
+function stopChat() {
+    if (stompClient) {
+        stompClient.disconnect(() => {
+            console.log('Disconnected from WebSocket');
+        });
+    }
+}
+
+// 채팅 메시지 송신 함수
+function sendChatMessage() {
+    const input = document.getElementById('message-input');
+    const messageText = input.value.trim();
+    console.log("Attempting to send message:", messageText);
+
+    if (!stompClient || !stompClient.connected) {
+        console.warn('WebSocket이 연결되어 있지 않습니다. 재연결 시도 후 다시 전송해 주세요.');
+        return;
+    }
+
+    if (messageText) {
+        const message = {
+            _id: "", // 서버 또는 DB에서 할당
+            chat_member_id: memberId,
+            chat_room_no : chatRoomNo,
+            chat_message: messageText,
+            chat_created_at: new Date().toLocaleString()
+        };
+        console.log("Sending message:", message);
+        stompClient.send('/pub/chat/message', {}, JSON.stringify(message));
+        input.value = ''; // 입력 필드 초기화
+    }
+}
+
+function parseJwt(token) {
+    if (!token) return null;
+    const base64Url = token.split('.')[1];
+    if (!base64Url) return null;
+    const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/');
+    try {
+        return JSON.parse(decodeURIComponent(escape(window.atob(base64))));
+    } catch (e) {
+        console.error('JWT 파싱 실패:', e);
+        return null;
+    }
+}
+
+
+function getCookieValue(cookieName) {
+    const cookies = document.cookie.split(';');
+    for (let cookie of cookies) {
+        const [name, value] = cookie.trim().split('=');
+        if (name === cookieName) {
+            return decodeURIComponent(value);
+        }
+    }
+    return null;
+}
+
+function addMessageToChat(message) {
+    // 채팅 메시지를 삽입할 요소 선택 (chat-messages div)
+    const chatMessagesContainer = document.getElementById('chat-messages');
+
+    // 새 메시지 요소 생성
+    const messageElement = document.createElement("div");
+    messageElement.classList.add("message");
+
+
+    // 사용자 아이디
+    const userNameSpan = document.createElement("span");
+    // userNameSpan.classList.add("user-name");
+    // userNameSpan.textContent = message.chat_member_id;
+
+    // 메시지 텍스트
+    const messageTextP = document.createElement("p");
+    messageTextP.classList.add("chat-text");
+    messageTextP.textContent = message.chat_message;
+
+    // 관리자인지 확인 (필요에 따라 조건 수정)
+    if(message.chat_member_id === "ADMIN") {
+        messageElement.classList.add("ADMIN");
+        userNameSpan.textContent = "관리자 ✓";
+        // 관리자 이름을 빨간색으로 표시
+        userNameSpan.style.color = "red";
+
+        // 관리자 메시지라고 구분할 클래스 추가 (CSS 활용 가능)
+        messageElement.classList.add("admin");
+
+        // 예시: “관리자가 작성한 채팅 입니다.”로 고정
+        messageTextP.textContent = message.chat_message;
+    } else {
+        messageElement.classList.add("USER");
+        userNameSpan.textContent = message.chat_member_id;
+        messageTextP.textContent = message.chat_message;
+    }
+
+    // 채팅 시간 (문자열 그대로 사용하거나, 포맷팅 가능)
+    // const chatTimeSpan = document.createElement("span");
+    // chatTimeSpan.classList.add("chat-time");
+    // chatTimeSpan.textContent = message.chat_created_at;
+
+    // 요소 조합
+    messageElement.appendChild(userNameSpan);
+    messageElement.appendChild(messageTextP);
+    // messageElement.appendChild(chatTimeSpan);
+
+    // 채팅 메시지 컨테이너에 추가
+    chatMessagesContainer.appendChild(messageElement);
+
+    // 자동 스크롤
+    setTimeout(() => {
+        chatMessagesContainer.scrollTop = chatMessagesContainer.scrollHeight;
+    }, 100);
+}

--- a/src/main/resources/static/js/chat/chatRoom.js
+++ b/src/main/resources/static/js/chat/chatRoom.js
@@ -58,25 +58,25 @@ function onError(error) {
     }, reconnectTimeout);
 }
 
-function createChatRoom() {
-    const chatContainer = document.getElementById('chat-container');
-    const scrollToLatestButton = document.getElementById('scroll-to-latest');
-
-    chatContainer.addEventListener('scroll', function () {
-        if (chatContainer.scrollTop + chatContainer.clientHeight < chatContainer.scrollHeight) {
-            scrollToLatestButton.style.display = 'block';
-        } else {
-            scrollToLatestButton.style.display = 'none';
-        }
-    });
-
-    scrollToLatestButton.addEventListener('click', function () {
-        chatContainer.scrollTop = chatContainer.scrollHeight;
-        scrollToLatestButton.style.display = 'none';
-    });
-
-
-}
+// function createChatRoom() {
+//     const chatContainer = document.getElementById('chat-messages');
+//     const scrollToLatestButton = document.getElementById('scroll-to-latest');
+//
+//     chatContainer.addEventListener('scroll', function () {
+//         if (chatContainer.scrollTop + chatContainer.clientHeight < chatContainer.scrollHeight) {
+//             scrollToLatestButton.style.display = 'block';
+//         } else {
+//             scrollToLatestButton.style.display = 'none';
+//         }
+//     });
+//
+//     scrollToLatestButton.addEventListener('click', function () {
+//         chatContainer.scrollTop = chatContainer.scrollHeight;
+//         scrollToLatestButton.style.display = 'none';
+//     });
+//
+//
+// }
 
 function stopChat() {
     if (stompClient) {
@@ -147,8 +147,8 @@ function addMessageToChat(message) {
 
     // 사용자 아이디
     const userNameSpan = document.createElement("span");
-    // userNameSpan.classList.add("user-name");
-    // userNameSpan.textContent = message.chat_member_id;
+    userNameSpan.classList.add("user-name");
+    userNameSpan.textContent = message.chat_member_id;
 
     // 메시지 텍스트
     const messageTextP = document.createElement("p");
@@ -183,6 +183,11 @@ function addMessageToChat(message) {
     } else {
         userNameSpan.textContent = message.chat_member_id;
         messageTextP.textContent = message.chat_message;
+
+        // (추가) 아이디 클릭 시 신고 모달 오픈
+        userNameSpan.addEventListener('click', () => {
+            openReportModal(message.chat_member_id, message.chat_message);
+        });
     }
 
     // 채팅 시간 (문자열 그대로 사용하거나, 포맷팅 가능)
@@ -204,34 +209,7 @@ function addMessageToChat(message) {
     }, 100);
 }
 
-// chatRoom.js (일부 예시)
-function addMessageToChat(message) {
-    const chatMessagesContainer = document.getElementById('chat-messages');
 
-    // 새 메시지 요소 생성
-    const messageElement = document.createElement("div");
-    messageElement.classList.add("message");
-
-    // 사용자 아이디
-    const userNameSpan = document.createElement("span");
-    userNameSpan.classList.add("user-name");
-    userNameSpan.textContent = message.chat_member_id;
-
-    // (추가) 아이디 클릭 시 신고 모달 오픈
-    userNameSpan.addEventListener('click', () => {
-        openReportModal(message.chat_member_id, message.chat_message);
-    });
-
-    // 메시지 텍스트
-    const messageTextP = document.createElement("p");
-    messageTextP.classList.add("chat-text");
-    messageTextP.textContent = message.chat_message;
-
-    // 요소 합치기
-    messageElement.appendChild(userNameSpan);
-    messageElement.appendChild(messageTextP);
-    chatMessagesContainer.appendChild(messageElement);
-}
 
 function openReportModal(memberId, chatMessage) {
     // 신고 대상 정보 세팅
@@ -280,4 +258,59 @@ document.addEventListener('DOMContentLoaded', () => {
     modalOverlay.addEventListener('click', () => {
         closeReportModal();
     });
+});
+
+document.addEventListener('DOMContentLoaded', () => {
+    const reportForm = document.getElementById('reportForm');    // 신고 폼
+    const cancelBtn = document.getElementById('cancelBtn');      // 신고 취소 버튼
+    const messageInput = document.getElementById('message-input'); // 채팅 입력창
+
+    const chatContainer = document.getElementById('chat-messages');
+    const scrollToLatestButton = document.getElementById('scroll-to-latest');
+
+
+    // 채팅 영역 스크롤 이벤트
+    chatContainer.addEventListener('scroll', function() {
+        // 스크롤 위치가 최하단에 가까운지 확인 (예: 50px 이상 차이날 때 버튼 표시)
+        if (chatContainer.scrollTop + chatContainer.clientHeight < chatContainer.scrollHeight - 20) {
+            scrollToLatestButton.style.display = 'block';
+        } else {
+            scrollToLatestButton.style.display = 'none';
+        }
+    });
+
+    // "최신 채팅으로 이동" 버튼 클릭 시 최하단으로 스크롤
+    scrollToLatestButton.addEventListener('click', function() {
+        chatContainer.scrollTop = chatContainer.scrollHeight;
+        scrollToLatestButton.style.display = 'none';
+    });
+
+    // 채팅 입력창에서 Enter 키로 메시지 전송
+    messageInput.addEventListener('keypress', (event) => {
+        if (event.key === 'Enter') {
+            event.preventDefault();   // Enter 시 줄바꿈 방지
+            sendChatMessage();       // 메시지 전송 함수 호출
+        }
+    });
+
+    // 폼 전송(신고하기) 버튼 클릭 시
+    if (reportForm) {
+        reportForm.addEventListener('submit', (e) => {
+            e.preventDefault();
+            const checkedReason = document.querySelector('input[name="reportReason"]:checked');
+            if (checkedReason) {
+                const reasonValue = checkedReason.value;
+                alert(`신고 사유: ${reasonValue}`);
+                // 팝업 닫기나 다른 처리 로직 추가
+            }
+        });
+    }
+
+    // 취소 버튼 클릭 시
+    if (cancelBtn) {
+        cancelBtn.addEventListener('click', () => {
+            alert('신고를 취소했습니다.');
+            // 팝업 닫기나 다른 처리 로직 추가
+        });
+    }
 });

--- a/src/main/resources/static/js/chat/chatRoom.js
+++ b/src/main/resources/static/js/chat/chatRoom.js
@@ -1,7 +1,7 @@
 let stompClient = null;
 let reconnectTimeout = 5000;
 
-window.onload = function() {
+window.onload = function () {
 
     // 쿠키에서 accessToken 추출
     const accessToken = getCookieValue("accessToken");
@@ -52,7 +52,7 @@ function onError(error) {
     console.error('STOMP error:', error);
 
     // 일정 시간 후 재연결 시도
-    setTimeout(function() {
+    setTimeout(function () {
         console.log('Attempting to reconnect...');
         connectToChatRoom();
     }, reconnectTimeout);
@@ -101,7 +101,7 @@ function sendChatMessage() {
         const message = {
             _id: "", // 서버 또는 DB에서 할당
             chat_member_id: memberId,
-            chat_room_no : chatRoomNo,
+            chat_room_no: chatRoomNo,
             chat_message: messageText,
             chat_created_at: new Date().toLocaleString()
         };
@@ -155,20 +155,32 @@ function addMessageToChat(message) {
     messageTextP.classList.add("chat-text");
     messageTextP.textContent = message.chat_message;
 
-    // 관리자인지 확인 (필요에 따라 조건 수정)
-    if(message.chat_member_id === "ADMIN") {
-        messageElement.classList.add("ADMIN");
+    // // 관리자인지 확인 (필요에 따라 조건 수정)
+    // if(message.chat_member_id === "ADMIN") {
+    //     messageElement.classList.add("ADMIN");
+    //     userNameSpan.textContent = "관리자 ✓";
+    //     // 관리자 이름을 빨간색으로 표시
+    //     userNameSpan.style.color = "red";
+    //
+    //     // 관리자 메시지라고 구분할 클래스 추가 (CSS 활용 가능)
+    //     messageElement.classList.add("admin");
+    //
+    //     // 예시: “관리자가 작성한 채팅 입니다.”로 고정
+    //     messageTextP.textContent = message.chat_message;
+    // } else {
+    //     messageElement.classList.add("USER");
+    //     userNameSpan.textContent = message.chat_member_id;
+    //     messageTextP.textContent = message.chat_message;
+    // }
+
+    if (message.chat_member_id === "admin01") {
         userNameSpan.textContent = "관리자 ✓";
         // 관리자 이름을 빨간색으로 표시
         userNameSpan.style.color = "red";
-
-        // 관리자 메시지라고 구분할 클래스 추가 (CSS 활용 가능)
         messageElement.classList.add("admin");
-
-        // 예시: “관리자가 작성한 채팅 입니다.”로 고정
+        messageTextP.style.color = "red";
         messageTextP.textContent = message.chat_message;
     } else {
-        messageElement.classList.add("USER");
         userNameSpan.textContent = message.chat_member_id;
         messageTextP.textContent = message.chat_message;
     }
@@ -191,3 +203,81 @@ function addMessageToChat(message) {
         chatMessagesContainer.scrollTop = chatMessagesContainer.scrollHeight;
     }, 100);
 }
+
+// chatRoom.js (일부 예시)
+function addMessageToChat(message) {
+    const chatMessagesContainer = document.getElementById('chat-messages');
+
+    // 새 메시지 요소 생성
+    const messageElement = document.createElement("div");
+    messageElement.classList.add("message");
+
+    // 사용자 아이디
+    const userNameSpan = document.createElement("span");
+    userNameSpan.classList.add("user-name");
+    userNameSpan.textContent = message.chat_member_id;
+
+    // (추가) 아이디 클릭 시 신고 모달 오픈
+    userNameSpan.addEventListener('click', () => {
+        openReportModal(message.chat_member_id, message.chat_message);
+    });
+
+    // 메시지 텍스트
+    const messageTextP = document.createElement("p");
+    messageTextP.classList.add("chat-text");
+    messageTextP.textContent = message.chat_message;
+
+    // 요소 합치기
+    messageElement.appendChild(userNameSpan);
+    messageElement.appendChild(messageTextP);
+    chatMessagesContainer.appendChild(messageElement);
+}
+
+function openReportModal(memberId, chatMessage) {
+    // 신고 대상 정보 세팅
+    const reportTargetText = document.getElementById('reportTargetText');
+    reportTargetText.textContent = `${memberId}님: ${chatMessage}`;
+
+    // 모달 & 오버레이 표시
+    const reportModal = document.getElementById('reportModal');
+    const modalOverlay = document.getElementById('modalOverlay');
+
+    reportModal.style.display = 'block';
+    modalOverlay.style.display = 'block';
+}
+
+// DOMContentLoaded 이후
+document.addEventListener('DOMContentLoaded', () => {
+    const reportForm = document.getElementById('reportForm');
+    const cancelBtn = document.getElementById('cancelBtn');
+    const reportModal = document.getElementById('reportModal');
+    const modalOverlay = document.getElementById('modalOverlay');
+
+    // 폼 전송(신고하기)
+    reportForm.addEventListener('submit', (e) => {
+        e.preventDefault();
+        const checkedReason = document.querySelector('input[name="reportReason"]:checked');
+        if (checkedReason) {
+            const reasonValue = checkedReason.value;
+            alert(`신고 사유: ${reasonValue}`);
+            closeReportModal();
+        }
+    });
+
+    // 취소 버튼
+    cancelBtn.addEventListener('click', () => {
+        alert('신고를 취소했습니다.');
+        closeReportModal();
+    });
+
+    // 모달 닫기 함수
+    function closeReportModal() {
+        reportModal.style.display = 'none';
+        modalOverlay.style.display = 'none';
+    }
+
+    // 모달 배경 클릭 시 닫히게 하려면
+    modalOverlay.addEventListener('click', () => {
+        closeReportModal();
+    });
+});

--- a/src/main/resources/templates/chat/chatRoom.html
+++ b/src/main/resources/templates/chat/chatRoom.html
@@ -3,26 +3,26 @@
       xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
       layout:decorate="layout.html">
 <div layout:fragment="content">
-    <link rel="stylesheet" href="/webjars/bootstrap/5.3.3/dist/css/bootstrap.min.css">
-    <link rel="stylesheet" href="/css/webrtc/kurento.css">
-    <link rel="stylesheet" href="/webjars/ekko-lightbox/5.2.0/dist/ekko-lightbox.css">
-    <link rel="stylesheet" href="/webjars/demo-console/1.5.1/index.css">
-    <link rel="stylesheet" href="/css/chat/chat.css">
-    <link rel="shortcut icon" href="/img/kurento.png" type="image/png"/>
+    <link rel="stylesheet" th:href="@{/webjars/bootstrap/5.3.3/dist/css/bootstrap.min.css}">
+    <link rel="stylesheet" th:href="@{/css/webrtc/kurento.css}">
+    <link rel="stylesheet" th:href="@{/webjars/ekko-lightbox/5.2.0/dist/ekko-lightbox.css}">
+    <link rel="stylesheet" th:href="@{/webjars/demo-console/1.5.1/index.css}">
+    <link rel="stylesheet" th:href="@{/css/chat/chat.css}">
+    <link rel="shortcut icon" th:href="@{/img/kurento.png}" type="image/png"/>
 
-    <script src="/webjars/jquery/3.7.1/dist/jquery.js"></script>
-    <script src="/webjars/bootstrap/5.3.3/dist/js/bootstrap.min.js"></script>
-    <script src="/webjars/webrtc-adapter/7.4.0/release/adapter.js"></script>
-    <script src="/webjars/demo-console/1.5.1/index.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/stompjs@2.3.3/lib/stomp.min.js"></script>
+    <script th:src="@{/webjars/jquery/3.7.1/dist/jquery.js}"></script>
+    <script th:src="@{/webjars/bootstrap/5.3.3/dist/js/bootstrap.min.js}"></script>
+    <script th:src="@{/webjars/webrtc-adapter/7.4.0/release/adapter.js}"></script>
+    <script th:src="@{/webjars/demo-console/1.5.1/index.js}"></script>
+    <script th:src="@{https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js}"></script>
+    <script th:src="@{https://cdn.jsdelivr.net/npm/stompjs@2.3.3/lib/stomp.min.js}"></script>
 
     <script th:inline="javascript">
         let chatRoomNo = [[${chatRoomNo}]];
         let memberId = [[${memberId}]];
     </script>
 
-    <script src="/js/chat/chatRoom.js"></script>
+    <script th:src="@{/js/chat/chatRoom.js}"></script>
 
     <div class="container">
         <!-- WebRTC Video Section -->
@@ -39,12 +39,8 @@
                 공지 | Live 방송 중에만 초특가 <strong>45% 세일 !!</strong>
             </div>
 
-            <!-- 채팅 메시지 영역 -->
-<!--            <div class="chat-wrapper" id="chat-wrapper">   -->
-<!--            </div>-->
-            <!-- 메시지는 초기에는 빈 상태이며, 실시간 WebSocket 메시지로 채워짐 -->
             <div class="chat-messages" id="chat-messages">
-                <!-- 초기 메시지가 필요하다면 여기에 추가 가능 -->
+                <!-- 초기 메시지 추가 가능 -->
             </div>
 
             <!-- 최신 채팅으로 이동 버튼 -->

--- a/src/main/resources/templates/chat/chatRoom.html
+++ b/src/main/resources/templates/chat/chatRoom.html
@@ -12,12 +12,17 @@
 
     <script src="/webjars/jquery/3.7.1/dist/jquery.js"></script>
     <script src="/webjars/bootstrap/5.3.3/dist/js/bootstrap.min.js"></script>
-    <script src="/webjars/ekko-lightbox/5.2.0/dist/ekko-lightbox.min.js"></script>
     <script src="/webjars/webrtc-adapter/7.4.0/release/adapter.js"></script>
     <script src="/webjars/demo-console/1.5.1/index.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/sockjs-client@1/dist/sockjs.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/stompjs@2.3.3/lib/stomp.min.js"></script>
 
-    <script src="/js/kurento-utils.js"></script>
-    <script src="/js/stream.js"></script>
+    <script th:inline="javascript">
+        let chatRoomNo = [[${chatRoomNo}]];
+        let memberId   = [[${memberId}]];
+    </script>
+
+    <script src="/js/chat/chatRoom.js"></script>
 
     <div class="container">
         <!-- WebRTC Video Section -->
@@ -28,29 +33,29 @@
             </div>
         </div>
 
-        <!-- Chat Room Section -->
-        <div class="chat-container" style="width: 300px; height: 480px; position: relative;">
-            <div class="chatRoom-container" id="chatRoom-container" style="display: block; width: 100%; height: 100%; position: relative;">
-                <!-- Chat Room Header -->
-                <div class="announcement" id="announcement">
-                    공지 | Live 방송 중에만 초특가 세일 !!
-                    <!-- Chat Messages -->
+        <div class="chat-container">
+            <!-- 공지 영역 -->
+            <div class="announcement">
+                공지 | Live 방송 중에만 초특가 <strong>45% 세일 !!</strong>
+            </div>
 
-                </div>
-                <div id="chat-container" class="chat-messages">
-                    <!-- 채팅 메시지가 여기에 추가됩니다 -->
-
-                    <!-- Scroll to Latest Button -->
-                    <button id="scroll-to-latest" class="scroll-button" style="display: none">↓ 최신 채팅으로 이동</button>
+            <!-- 채팅 메시지 영역 -->
+            <div class="chat-wrapper">
+                <!-- 메시지는 초기에는 빈 상태이며, 실시간 WebSocket 메시지로 채워짐 -->
+                <div class="chat-messages" id="chat-messages">
+                    <!-- 초기 메시지가 필요하다면 여기에 추가 가능 -->
                 </div>
 
+                <!-- 최신 채팅으로 이동 버튼 -->
+                <button id="scroll-to-latest" class="scroll-button">
+                    ↓ 최신 채팅으로 이동
+                </button>
+            </div>
 
-
-                <!-- Chat Input -->
-                <div class="input-container">
-                    <input type="text" id="message-input" placeholder="메시지 입력">
-                    <button id="send-button">➤</button>
-                </div>
+            <!-- 메시지 입력 영역 -->
+            <div class="input-container">
+                <input type="text" id="message-input" placeholder="메시지 입력">
+                <button id="send-button">➤</button>
             </div>
         </div>
 
@@ -81,7 +86,7 @@
 
             <!-- Chat Buttons -->
             <div>
-                <button id="chatPresenter" class="btn btn-success" onclick="createChatRoom()">
+                <button id="chatStart" class="btn btn-success" onclick="createChatRoom()">
                     채팅시작
                 </button>
                 <button id="chatStop" href="#" class="btn btn-danger" onclick="stopChat()">
@@ -90,112 +95,6 @@
             </div>
         </div>
     </div>
-
-    <!-- JavaScript for Chat Room -->
-    <script src="/sockjs.min.js"></script>
-    <script src="/stomp.min.js"></script>
-    <script>
-        let stompClient;
-        const chatRoomNo = 101; // Example chat room number
-        const currentUserId = 'user1'; // 현재 사용자의 아이디 (예제)
-
-        function createChatRoom() {
-            // Show the chat room container
-            document.getElementById('chatRoom-container').style.display = 'block';
-
-            // Initialize WebSocket connection
-            const socket = new SockJS('/ws-stomp');
-            stompClient = Stomp.over(socket);
-
-            stompClient.connect({}, function () {
-                console.log('Connected to WebSocket');
-
-                // Subscribe to the chat room topic
-                stompClient.subscribe(`/sub/chat/room/${chatRoomNo}`, function (message) {
-                    showMessage(JSON.parse(message.body));
-                });
-            });
-
-            // Add event listener for sending messages
-            document.getElementById('send-button').addEventListener('click', sendMessage);
-
-            // Add scroll event listener for the chat container
-            const chatContainer = document.getElementById('chat-container');
-            const scrollToLatestButton = document.getElementById('scroll-to-latest');
-
-            chatContainer.addEventListener('scroll', function () {
-                if (chatContainer.scrollTop + chatContainer.clientHeight < chatContainer.scrollHeight) {
-                    scrollToLatestButton.style.display = 'block'; // 스크롤이 위로 올라갔을 때 버튼 표시
-                } else {
-                    scrollToLatestButton.style.display = 'none'; // 스크롤이 맨 아래일 때 버튼 숨김
-                }
-            });
-
-            // Scroll to the latest message when the button is clicked
-            scrollToLatestButton.addEventListener('click', function () {
-                chatContainer.scrollTop = chatContainer.scrollHeight; // 스크롤을 맨 아래로 이동
-                scrollToLatestButton.style.display = 'none'; // 버튼 숨김
-            });
-        }
-
-        function stopChat() {
-            if (stompClient) {
-                stompClient.disconnect();
-                console.log('Disconnected from WebSocket');
-            }
-            document.getElementById('chatRoom-container').style.display = 'none';
-        }
-
-        function sendMessage() {
-            const inputField = document.getElementById('message-input');
-            const messageText = inputField.value.trim();
-
-            if (!messageText) {
-                alert('메시지를 입력해주세요.');
-                return;
-            }
-
-            const message = {
-                chatStreamNo: 101,
-                chatMemberNo: 1001,
-                chatRoomNo: Number(chatRoomNo),
-                chatMessage: messageText,
-                sender: currentUserId, // 현재 사용자의 아이디를 전송
-                type: 'TALK'
-            };
-
-            stompClient.send('/pub/chat/message', {}, JSON.stringify(message));
-            inputField.value = '';
-        }
-
-        function showMessage(message) {
-            const chatContainer = document.getElementById('chat-container');
-
-            // 새로운 메시지 요소 생성
-            const newMessage = document.createElement('div');
-            newMessage.classList.add('chat-message', message.type === 'ADMIN' ? 'admin' : 'user');
-
-            // 유저 아이디와 메시지 내용 표시
-            newMessage.innerHTML = `
-            <span class="username" style="font-weight: bold; color: ${message.sender === currentUserId ? '#007bff' : '#333'};">
-                ${message.sender || '사용자'}
-            </span>:
-            <span class="message" style="color: #555;">
-                ${message.chatMessage}
-            </span>
-        `;
-
-            // 메시지를 채팅 컨테이너에 추가
-            chatContainer.appendChild(newMessage);
-
-            // 자동 스크롤 (최신 메시지로 이동)
-            setTimeout(() => {
-                chatContainer.scrollTop = chatContainer.scrollHeight;
-            }, 100);
-        }
-    </script>
-
-
 </div>
 </body>
 </html>

--- a/src/main/resources/templates/chat/chatRoom.html
+++ b/src/main/resources/templates/chat/chatRoom.html
@@ -40,17 +40,17 @@
             </div>
 
             <!-- 채팅 메시지 영역 -->
-            <div class="chat-wrapper">
-                <!-- 메시지는 초기에는 빈 상태이며, 실시간 WebSocket 메시지로 채워짐 -->
-                <div class="chat-messages" id="chat-messages">
-                    <!-- 초기 메시지가 필요하다면 여기에 추가 가능 -->
-                </div>
-
-                <!-- 최신 채팅으로 이동 버튼 -->
-                <button id="scroll-to-latest" class="scroll-button">
-                    ↓ 최신 채팅으로 이동
-                </button>
+<!--            <div class="chat-wrapper" id="chat-wrapper">   -->
+<!--            </div>-->
+            <!-- 메시지는 초기에는 빈 상태이며, 실시간 WebSocket 메시지로 채워짐 -->
+            <div class="chat-messages" id="chat-messages">
+                <!-- 초기 메시지가 필요하다면 여기에 추가 가능 -->
             </div>
+
+            <!-- 최신 채팅으로 이동 버튼 -->
+            <button id="scroll-to-latest" class="scroll-button" style="display:none;">
+                ↓ 최신 채팅으로 이동
+            </button>
 
             <!-- 메시지 입력 영역 -->
             <div class="input-container">
@@ -66,6 +66,8 @@
             </div>
         </div>
     </div>
+
+    <div class="modal-overlay" id="modalOverlay" style="display:none;"></div>
 
     <div class="report-modal" id="reportModal">
         <h2>채팅 신고</h2>

--- a/src/main/resources/templates/chat/chatRoom.html
+++ b/src/main/resources/templates/chat/chatRoom.html
@@ -19,7 +19,7 @@
 
     <script th:inline="javascript">
         let chatRoomNo = [[${chatRoomNo}]];
-        let memberId   = [[${memberId}]];
+        let memberId = [[${memberId}]];
     </script>
 
     <script src="/js/chat/chatRoom.js"></script>
@@ -65,6 +65,39 @@
                 <h1>상품화면</h1>
             </div>
         </div>
+    </div>
+
+    <div class="report-modal" id="reportModal">
+        <h2>채팅 신고</h2>
+        <p class="description">신고 사유를 선택해 주세요.</p>
+        <form id="reportForm">
+            <div class="radio-group">
+                <label class="radio-label">
+                    <input type="radio" name="reportReason" value="음란성, 폭력성 또는 괴롭힘" required/>
+                    음란성, 폭력성 또는 괴롭힘
+                </label>
+                <label class="radio-label">
+                    <input type="radio" name="reportReason" value="비방 및 명예훼손"/>
+                    비방 및 명예훼손
+                </label>
+                <label class="radio-label">
+                    <input type="radio" name="reportReason" value="스팸 및 도배 행위"/>
+                    스팸 및 도배 행위
+                </label>
+                <label class="radio-label">
+                    <input type="radio" name="reportReason" value="광고성 또는 부적절한 발언"/>
+                    광고성 또는 부적절한 발언
+                </label>
+            </div>
+            <div class="report-content">
+                <!-- 신고 대상 정보가 동적으로 들어갈 부분 -->
+                <p class="chatContent" id="reportTargetText">신고 대상의 채팅 내용</p>
+            </div>
+            <div class="button-group">
+                <button type="button" id="cancelBtn">취소</button>
+                <button type="submit" id="submitBtn">신고하기</button>
+            </div>
+        </form>
     </div>
 
     <!-- Buttons for WebRTC and Chat -->

--- a/src/main/resources/templates/chat/chatRoom.html
+++ b/src/main/resources/templates/chat/chatRoom.html
@@ -1,0 +1,201 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="layout.html">
+<div layout:fragment="content">
+    <link rel="stylesheet" href="/webjars/bootstrap/5.3.3/dist/css/bootstrap.min.css">
+    <link rel="stylesheet" href="/css/webrtc/kurento.css">
+    <link rel="stylesheet" href="/webjars/ekko-lightbox/5.2.0/dist/ekko-lightbox.css">
+    <link rel="stylesheet" href="/webjars/demo-console/1.5.1/index.css">
+    <link rel="stylesheet" href="/css/chat/chat.css">
+    <link rel="shortcut icon" href="/img/kurento.png" type="image/png"/>
+
+    <script src="/webjars/jquery/3.7.1/dist/jquery.js"></script>
+    <script src="/webjars/bootstrap/5.3.3/dist/js/bootstrap.min.js"></script>
+    <script src="/webjars/ekko-lightbox/5.2.0/dist/ekko-lightbox.min.js"></script>
+    <script src="/webjars/webrtc-adapter/7.4.0/release/adapter.js"></script>
+    <script src="/webjars/demo-console/1.5.1/index.js"></script>
+
+    <script src="/js/kurento-utils.js"></script>
+    <script src="/js/stream.js"></script>
+
+    <div class="container">
+        <!-- WebRTC Video Section -->
+        <div class="live-container">
+            <div id="video">
+                <video id="live-video" autoplay width="300px" height="480px"
+                       poster="/img/webrtc.png"></video>
+            </div>
+        </div>
+
+        <!-- Chat Room Section -->
+        <div class="chat-container" style="width: 300px; height: 480px; position: relative;">
+            <div class="chatRoom-container" id="chatRoom-container" style="display: block; width: 100%; height: 100%; position: relative;">
+                <!-- Chat Room Header -->
+                <div class="announcement" id="announcement">
+                    공지 | Live 방송 중에만 초특가 세일 !!
+                    <!-- Chat Messages -->
+
+                </div>
+                <div id="chat-container" class="chat-messages">
+                    <!-- 채팅 메시지가 여기에 추가됩니다 -->
+
+                    <!-- Scroll to Latest Button -->
+                    <button id="scroll-to-latest" class="scroll-button" style="display: none">↓ 최신 채팅으로 이동</button>
+                </div>
+
+
+
+                <!-- Chat Input -->
+                <div class="input-container">
+                    <input type="text" id="message-input" placeholder="메시지 입력">
+                    <button id="send-button">➤</button>
+                </div>
+            </div>
+        </div>
+
+        <!-- Product Section -->
+        <div class="product-container">
+            <div id="product">
+                <h1>상품화면</h1>
+            </div>
+        </div>
+    </div>
+
+    <!-- Buttons for WebRTC and Chat -->
+    <br>
+    <div class="container">
+        <div class="settings-buttons">
+            <!-- WebRTC Buttons -->
+            <div>
+                <button id="presenter" class="btn btn-success" onclick="presenter()">
+                    송출시작
+                </button>
+                <button id="viewer" class="btn btn-primary" onclick="viewer()">
+                    방송시청
+                </button>
+                <button id="stop" href="#" class="btn btn-danger" onclick="stop()">
+                    송출종료
+                </button>
+            </div>
+
+            <!-- Chat Buttons -->
+            <div>
+                <button id="chatPresenter" class="btn btn-success" onclick="createChatRoom()">
+                    채팅시작
+                </button>
+                <button id="chatStop" href="#" class="btn btn-danger" onclick="stopChat()">
+                    채팅종료
+                </button>
+            </div>
+        </div>
+    </div>
+
+    <!-- JavaScript for Chat Room -->
+    <script src="/sockjs.min.js"></script>
+    <script src="/stomp.min.js"></script>
+    <script>
+        let stompClient;
+        const chatRoomNo = 101; // Example chat room number
+        const currentUserId = 'user1'; // 현재 사용자의 아이디 (예제)
+
+        function createChatRoom() {
+            // Show the chat room container
+            document.getElementById('chatRoom-container').style.display = 'block';
+
+            // Initialize WebSocket connection
+            const socket = new SockJS('/ws-stomp');
+            stompClient = Stomp.over(socket);
+
+            stompClient.connect({}, function () {
+                console.log('Connected to WebSocket');
+
+                // Subscribe to the chat room topic
+                stompClient.subscribe(`/sub/chat/room/${chatRoomNo}`, function (message) {
+                    showMessage(JSON.parse(message.body));
+                });
+            });
+
+            // Add event listener for sending messages
+            document.getElementById('send-button').addEventListener('click', sendMessage);
+
+            // Add scroll event listener for the chat container
+            const chatContainer = document.getElementById('chat-container');
+            const scrollToLatestButton = document.getElementById('scroll-to-latest');
+
+            chatContainer.addEventListener('scroll', function () {
+                if (chatContainer.scrollTop + chatContainer.clientHeight < chatContainer.scrollHeight) {
+                    scrollToLatestButton.style.display = 'block'; // 스크롤이 위로 올라갔을 때 버튼 표시
+                } else {
+                    scrollToLatestButton.style.display = 'none'; // 스크롤이 맨 아래일 때 버튼 숨김
+                }
+            });
+
+            // Scroll to the latest message when the button is clicked
+            scrollToLatestButton.addEventListener('click', function () {
+                chatContainer.scrollTop = chatContainer.scrollHeight; // 스크롤을 맨 아래로 이동
+                scrollToLatestButton.style.display = 'none'; // 버튼 숨김
+            });
+        }
+
+        function stopChat() {
+            if (stompClient) {
+                stompClient.disconnect();
+                console.log('Disconnected from WebSocket');
+            }
+            document.getElementById('chatRoom-container').style.display = 'none';
+        }
+
+        function sendMessage() {
+            const inputField = document.getElementById('message-input');
+            const messageText = inputField.value.trim();
+
+            if (!messageText) {
+                alert('메시지를 입력해주세요.');
+                return;
+            }
+
+            const message = {
+                chatStreamNo: 101,
+                chatMemberNo: 1001,
+                chatRoomNo: Number(chatRoomNo),
+                chatMessage: messageText,
+                sender: currentUserId, // 현재 사용자의 아이디를 전송
+                type: 'TALK'
+            };
+
+            stompClient.send('/pub/chat/message', {}, JSON.stringify(message));
+            inputField.value = '';
+        }
+
+        function showMessage(message) {
+            const chatContainer = document.getElementById('chat-container');
+
+            // 새로운 메시지 요소 생성
+            const newMessage = document.createElement('div');
+            newMessage.classList.add('chat-message', message.type === 'ADMIN' ? 'admin' : 'user');
+
+            // 유저 아이디와 메시지 내용 표시
+            newMessage.innerHTML = `
+            <span class="username" style="font-weight: bold; color: ${message.sender === currentUserId ? '#007bff' : '#333'};">
+                ${message.sender || '사용자'}
+            </span>:
+            <span class="message" style="color: #555;">
+                ${message.chatMessage}
+            </span>
+        `;
+
+            // 메시지를 채팅 컨테이너에 추가
+            chatContainer.appendChild(newMessage);
+
+            // 자동 스크롤 (최신 메시지로 이동)
+            setTimeout(() => {
+                chatContainer.scrollTop = chatContainer.scrollHeight;
+            }, 100);
+        }
+    </script>
+
+
+</div>
+</body>
+</html>

--- a/src/test/java/com/ssginc/showpinglive/chat/MongoDbConnectionTest.java
+++ b/src/test/java/com/ssginc/showpinglive/chat/MongoDbConnectionTest.java
@@ -1,0 +1,47 @@
+package com.ssginc.showpinglive.chat;
+
+import com.ssginc.showpinglive.dto.object.ChatDto;
+import com.ssginc.showpinglive.repository.ChatRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@TestPropertySource(properties = "de.flapdoodle.mongodb.embedded.version=5.0.5")
+public class MongoDbConnectionTest {
+
+    @Autowired
+    private ChatRepository chatRepository;
+
+    @Test
+    public void testMongoDbConnection() {
+        // 1. 테스트 데이터 생성
+        ChatDto message = new ChatDto();
+        message.setChatStreamNo(101L);
+        message.setChatMemberNo(1001L);
+        message.setChatRoomNo(2001L);
+        message.setChatMessage("테스트 메시지");
+        message.setChatCreatedAt(LocalDateTime.now());
+
+        // 2. 데이터 저장
+        ChatDto savedMessage = chatRepository.save(message);
+
+        // 3. 저장된 데이터 검증
+        assertThat(savedMessage).isNotNull(); // 저장된 객체가 null이 아닌지 확인
+        assertThat(savedMessage.getId()).isNotNull(); // _id 필드가 생성되었는지 확인
+        assertThat(savedMessage.getChatStreamNo()).isEqualTo(101L); // 데이터 값 검증
+        assertThat(savedMessage.getChatMemberNo()).isEqualTo(1001L);
+        assertThat(savedMessage.getChatRoomNo()).isEqualTo(2001L);
+        assertThat(savedMessage.getChatMessage()).isEqualTo("테스트 메시지");
+
+        // 4. 저장된 데이터를 다시 조회하여 검증
+        ChatDto retrievedMessage = chatRepository.findById(savedMessage.getId()).orElse(null);
+        assertThat(retrievedMessage).isNotNull(); // 조회된 객체가 null이 아닌지 확인
+        assertThat(retrievedMessage.getChatStreamNo()).isEqualTo(101L); // 데이터 값 검증
+    }
+}


### PR DESCRIPTION
## 내용
- 기본 채팅 구현 완료
   - JWT Token 이용. 
   - Websocket STOMP 이용
   - Kafka 이용 (chat-messages topic으로 메세지 전송)
   - 몽고DB에 정상 저장
   - 최신 채팅으로 이동 버튼
   - 관리자 채팅은 특별하게 표시
   - 다중 채팅 테스트 완료
   - 부적절한 채팅을 친 유저 ID를 눌렀을 시 신고창 modal
   - 참고사항 : showping에 올라와 있는 로그인 기능으로는 테스트 하지 못함. 간단하게 로그인 구현하여 그걸 바탕으로 구현 및 테스트 완료.
   

  
## 관련 issue
- #10 